### PR TITLE
Initialize the samples key and skip counter when samples is empty

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -168,6 +168,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'sample' => [],
             ];
             foreach (new APCUIterator('/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -179,8 +180,11 @@ class APC implements Adapter
                     'value' => $value['value'],
                 ];
             }
-            $this->sortSamples($data['samples']);
-            $counters[] = new MetricFamilySamples($data);
+
+            if (!empty($data['samples'])) {
+                $this->sortSamples($data['samples']);
+                $counters[] = new MetricFamilySamples($data);
+            }
         }
         return $counters;
     }
@@ -198,6 +202,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => [],
             ];
             foreach (new APCUIterator('/^prom:gauge:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -210,8 +215,10 @@ class APC implements Adapter
                 ];
             }
 
-            $this->sortSamples($data['samples']);
-            $gauges[] = new MetricFamilySamples($data);
+            if (!empty($data['samples'])) {
+                $this->sortSamples($data['samples']);
+                $gauges[] = new MetricFamilySamples($data);
+            }
         }
         return $gauges;
     }

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -168,7 +168,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
-                'sample' => [],
+                'samples' => [],
             ];
             foreach (new APCUIterator('/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);


### PR DESCRIPTION
The purpose of this PR is to fix the following error: 

```
"PHP message: PHP Fatal error: Uncaught TypeError: Argument 1 passed to Prometheus\Storage\APC::sortSamples() must be of the type array, null given, called in [omissis]vendor/endclothing/prometheus_client_php/src/Prometheus/Storage/APC.php on line 181 and defined in [omissis]vendor/endclothing/prometheus_client_php/src/Prometheus/Storage/APC.php:315
```

After an investigation, we spotted this error happens in one of the pods probably due to counter with empty value. 
